### PR TITLE
Add GoDoc badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ignite-go-client
 
+[![GoDoc](http://www.godoc.org/github.com/amsokol/ignite-go-client?status.svg)](http://www.godoc.org/github.com/amsokol/ignite-go-client)
+
 ## Apache Ignite (GridGain) v2.4+ client for Go programming language
 
 This library is production ready.


### PR DESCRIPTION
Most projects on GitHub have a bunch of badges in their README, and Go projects in particular have at least a GoDoc badge. This makes it easy for package users to immediately jump to the reference documentation.

This PR currently leads to the GoDoc badge pointing to the GoDoc of `github.com/amsokol/ignite-go-client`.