### PR TITLE
Add dummy NamedValueChecker (fixes issues with mismatched types)

### DIFF
--- a/sql/v1/conn.go
+++ b/sql/v1/conn.go
@@ -24,6 +24,7 @@ type conn struct {
 	driver.ExecerContext
 	driver.Pinger
 	driver.QueryerContext
+	driver.NamedValueChecker
 }
 
 // isConnected return true if connection to the cluster is active
@@ -38,6 +39,15 @@ func (c *conn) resourceClose(id int64) error {
 	}
 	return c.client.ResourceClose(id)
 }
+
+// <driver.NamedValueChecker>
+
+func (c *conn) CheckNamedValue(val *driver.NamedValue) error {
+	// Ignore and handle later
+	return nil
+}
+
+// </driver.NamedValueChecker>
 
 // <driver.Conn>
 


### PR DESCRIPTION
I was suffering from a bug where my `int32`'s were being converted to `int64`'s, which was causing Ignite to think that columns didn't match for fields defined as `java.lang.Integer`. Specifically;

```go
var i int32
i = 1
db.Exec("INSERT INTO FOO (ID) VALUES (?)", i)
result, _ := db.Exec("DELETE FROM FOO WHERE ID = ?", i)
affectedRows := result.AffectedRows()
fmt.Printf("%d", affectedRows)
```
Which would output a lovely `0`.

I discovered that Go is automatically converting the value of `driver.NamedValue.Value` to `int64`. I noticed you already do your own type conversions after Go has converted the value, so I created a dummy `CheckNamedValue`, which prevents Go from doing any conversions. This appears to have resolved my problem.