### PR TITLE
Fix UUID being read/written incorrectly

### DIFF
--- a/binary/v1/types.go
+++ b/binary/v1/types.go
@@ -122,6 +122,18 @@ func ToTime(t time.Time) Time {
 	return Time(t3)
 }
 
+// Flips a UUID buffer into the right order
+func uuidFlip(id *uuid.UUID) {
+	for i := 3; i >= 0; i-- {
+		opp := 7-i
+		id[i], id[opp] = id[opp], id[i]
+	}
+	for i := 3; i >= 0; i-- {
+		opp := 15-i
+		id[i+8], id[opp] = id[opp], id[i+8]
+	}
+}
+
 // WriteType writes object type code
 func WriteType(w io.Writer, code byte) error {
 	return WriteByte(w, code)
@@ -250,6 +262,7 @@ func WriteOUUID(w io.Writer, v uuid.UUID) error {
 	if err := WriteType(w, typeUUID); err != nil {
 		return err
 	}
+	uuidFlip(&v)
 	return binary.Write(w, binary.LittleEndian, v)
 }
 
@@ -714,6 +727,7 @@ func ReadOString(r io.Reader) (string, error) {
 func ReadUUID(r io.Reader) (uuid.UUID, error) {
 	var o uuid.UUID
 	err := binary.Read(r, binary.LittleEndian, &o)
+	uuidFlip(&o)
 	return o, err
 }
 


### PR DESCRIPTION
It appears the order of the UUID is being read/written incorrectly. A UUID created with `uuid.New()` creates an element with the bytes:
```
[175 95 101 190 208 84 73 41 180 30 81 75 208 199 210 227]
```
However the order written to the database is:
```
[41 73 84 208 190 101 95 175 227 210 199 208 75 81 30 180]
```

It seems like bytes [:7] and [8:] are flipped. I've injected a function that flips them into the correct order. I have confirmed that the UUID produced by `uuid.New()` matches the UUID returned via the SQLLine tool bundled with Ignite.